### PR TITLE
PHP7 Fix

### DIFF
--- a/PFBC/Base.php
+++ b/PFBC/Base.php
@@ -27,7 +27,7 @@ abstract class Base {
 					/*If the appropriate class has a "set" method for the property provided, then
 					it is called instead or setting the property directly.*/
 					if(isset($method_reference["set" . $property]))
-						$this->$method_reference["set" . $property]($value);
+						$this->{$method_reference["set" . $property]}($value);
 					elseif(isset($property_reference[$property]))
 						$this->$property_reference[$property] = $value;
 					/*Entries that don't match an available class property are stored in the attributes

--- a/PFBC/Base.php
+++ b/PFBC/Base.php
@@ -29,7 +29,7 @@ abstract class Base {
 					if(isset($method_reference["set" . $property]))
 						$this->{$method_reference["set" . $property]}($value);
 					elseif(isset($property_reference[$property]))
-						$this->$property_reference[$property] = $value;
+						$this->{$property_reference[$property]} = $value;
 					/*Entries that don't match an available class property are stored in the attributes
 					property if applicable.  Typically, these entries will be element attributes such as
 					class, value, onkeyup, etc.*/


### PR DESCRIPTION
See below for details:
http://stackoverflow.com/questions/34506185/php7-method-exists-uncaught-error-function-name-must-be-a-string

(Not 100% sure if this fix is backwards compatible but I think it is)